### PR TITLE
changed video gallery formatting for tablet and mobile

### DIFF
--- a/src/css/Gallery.css
+++ b/src/css/Gallery.css
@@ -11,7 +11,7 @@
     margin-top: 5%;
 }
 
-.text-modal-container {
+.photos-container {
     display: flex;
 }
 
@@ -22,7 +22,7 @@
     margin-top: 30px;
 }
 
-.gallery-text-container {
+.videos-container {
     float: left;
     margin-left: 7%;
     margin-right: 3%;
@@ -78,7 +78,7 @@
         height: 200px;;
     }
 
-    .gallery-text-container {
+    .videos-container {
         float: none;
         margin: auto;
         width: 100%;
@@ -110,7 +110,7 @@
 }
 
 @media only screen and (max-width: 600px) {
-    .text-modal-container {
+    .photos-container {
         display: inline;
     }
 
@@ -140,12 +140,6 @@
        margin-left: 0px;
        margin-top: 30px;
        margin-bottom: 20px;
-    }
-
-    .bottom-absolute {
-        bottom: 0;
-        position: absolute;
-        width: 100%;
     }
 
     .tabholder {

--- a/src/css/Gallery.css
+++ b/src/css/Gallery.css
@@ -73,21 +73,22 @@
 @media only screen and (max-width: 800px) {
     .DPT-logo {
         width: 200px;
-        height: 200px;;
+        height: 200px;
     }
 
     .videos-container {
         float: none;
         margin: auto;
         width: 100%;
+        margin-bottom: -15%;
     }
 
     .youtube-iframe {
-        margin-top: -10%;
+        margin-top: -20%;
         display: block;
         width: 70%;
         height: 40vw;
-        margin-left: 13%;
+        margin: auto;
     }
 
     .tab-title {
@@ -96,7 +97,7 @@
     }
 
     .tabholder {
-        font-size: 15px;
+        font-size: 25px;
     }
 
     .subscribe-text {
@@ -114,6 +115,10 @@
 
     .youtube-iframe {
         width: 100%;
+    }
+
+    .videos-container {
+        margin-bottom: -25%;
     }
 
     .DPT-logo {

--- a/src/css/Gallery.css
+++ b/src/css/Gallery.css
@@ -84,11 +84,10 @@
 
     .youtube-iframe {
         margin-top: -10%;
-        padding-left: 20px;
         display: block;
         width: 70%;
         height: 40vw;
-        margin-left: 12%;
+        margin-left: 13%;
     }
 
     .tab-title {

--- a/src/css/Gallery.css
+++ b/src/css/Gallery.css
@@ -56,6 +56,7 @@
 }
 
 @media only screen and (max-width: 1100px) {
+
     .youtube-iframe {
         height: 400px;
     }
@@ -66,18 +67,27 @@
 
     .tab-title {
         font-size: 5vw;
+        text-align: center;
     }
+
 }
 
 @media only screen and (max-width: 800px) {
     .DPT-logo {
-        margin-top: 5%;
-        width: 15%;
-        height: 15%;
+        width: 200px;
+        height: 200px;;
+    }
+
+    .gallery-text-container {
+        float: none;
+        margin: auto;
+        width: 100%;
     }
 
     .youtube-iframe {
-        margin-top: 0px;
+        margin-top: -10%;
+        padding-left: 20px;
+        display: block;
         width: 70%;
         height: 40vw;
     }
@@ -92,7 +102,7 @@
     }
 
     .subscribe-text {
-        margin-top: 3%;
+        margin-top: -3%;
         font-size: 22px;
         padding-left: 5%;
         padding-right: 5%;
@@ -110,19 +120,18 @@
     }
 
     .DPT-logo {
-        margin-top: 5%;
-        width: 12%;
-        height: 12%;
+        margin-top: -5%;
+        width: 150px;
+        height: 150px;
     }
 
     .youtube-iframe {
-        margin-top: 0px;
+        margin-top: -25%;
         width: 70%;
         height: 40vw;
     }
 
     .subscribe-text {
-        margin-top: 5%;
         font-size: 4.2vw;
     }
 

--- a/src/css/Gallery.css
+++ b/src/css/Gallery.css
@@ -16,7 +16,6 @@
 }
 
 .youtube-iframe {
-    margin: auto;
     height: 30vw;
     width: 50%;
     margin-top: 30px;
@@ -56,7 +55,6 @@
 }
 
 @media only screen and (max-width: 1100px) {
-
     .youtube-iframe {
         height: 400px;
     }
@@ -90,6 +88,7 @@
         display: block;
         width: 70%;
         height: 40vw;
+        margin-left: 12%;
     }
 
     .tab-title {
@@ -116,7 +115,6 @@
 
     .youtube-iframe {
         width: 100%;
-
     }
 
     .DPT-logo {

--- a/src/pages/About/Gallery.js
+++ b/src/pages/About/Gallery.js
@@ -6,39 +6,14 @@ import '../../css/Gallery.css';
 import { Tabs, TabPane } from 'react-bootstrap';
 
 class Gallery extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-       isDesktop: true
-    };
-
-    this.updateWindowDimensions = this.updateWindowDimensions.bind(this);
-  }
-
-  componentDidMount() {
-    this.updateWindowDimensions();
-    console.log(window.innerHeight, window.innerWidth);
-		window.addEventListener('resize', this.updateWindowDimensions);
-	}
-	
-	updateWindowDimensions() {
-		if (window.innerWidth > 800 && !this.state.isDesktop){
-			this.setState({ isDesktop: true });
-		}
-    
-    if(window.innerWidth <= 800 && this.state.isDesktop){
-			this.setState({ isDesktop: false });
-		}
-	}
   render() {
-
     return(
       <div>
          <Toolbar />
          <Tabs className="tabholder" fill defaultActiveKey="photos">
            <TabPane eventKey="photos" title="Photos">
              <div style={{display:"flex", justifyContent:"center", alignItems:"center", flexDirection:"column"}}>
-             <div className="text-modal-container"> 
+             <div className="photos-container"> 
                <h1 className="tab-title"> Photo Gallery </h1>
              </div> 
             <GalleryImages/>
@@ -49,7 +24,7 @@ class Gallery extends Component {
            <TabPane eventKey="videos" title="Videos">
               <div>
                 <div style={{alignItems: "center", justifyContent: "center"}}>
-                  <div className="gallery-text-container"> 
+                  <div className="videos-container"> 
                     <h1 className="tab-title"> Video Gallery </h1>
                     <img className="DPT-logo" src={require("../../images/logo1.png")}></img>
                     <br />

--- a/src/pages/About/Gallery.js
+++ b/src/pages/About/Gallery.js
@@ -47,9 +47,6 @@ class Gallery extends Component {
             </TabPane>
          
            <TabPane eventKey="videos" title="Videos">
-            {/*Render first div if window is desktop size, render second div if tablet or mobile*/}
-            {
-            this.state.isDesktop ? 
               <div>
                 <div style={{alignItems: "center", justifyContent: "center"}}>
                   <div className="gallery-text-container"> 
@@ -63,21 +60,6 @@ class Gallery extends Component {
                 <iframe className="youtube-iframe" src="https://www.youtube.com/embed/+lastest?list=PLCyEpHAXCjJMDXWsfMdWfD1NHh3zoYa1m" frameborder="0" allowFullScreen></iframe>
                 <Footer />
               </div>
-            : 
-              <div> 
-                <div style={{display: "flex", flexDirection: "row", alignItems: "center", justifyContent: "center"}}> 
-                  <img className="DPT-logo" src={require("../../images/logo1.png")}></img>
-                  <h1 className="tab-title"> Video Gallery </h1>
-                </div>
-
-                <div style={{display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center"}}>  
-                  <iframe className="youtube-iframe" src="https://www.youtube.com/embed/+lastest?list=PLCyEpHAXCjJMDXWsfMdWfD1NHh3zoYa1m" frameborder="0" allowFullScreen></iframe>
-                  <p className="subscribe-text"> For more videos, click <a style={{color: '#FF4081'}} target="_blank" href="https://www.youtube.com/channel/UCLVld8eG5THi_R1MpLobU4g">here</a> to subscribe to our Youtube channel! </p>
-                </div>  
-
-                {(window.innerWidth <= 600 && window.innerHeight < 900) ? <div className="bottom-absolute"> <Footer/> </div> : <Footer />}
-              </div>
-          }
           </TabPane>
          </Tabs>
       </div>


### PR DESCRIPTION
The pr changes the way the video gallery looks for mobile and tablet screens. The previous format was causing two issues:
- On the ipad and iphone devices that I viewed the website on, only one image would load for the gallery page. (Not sure how the video gallery was messing up the photo gallery, but I believe it had something to do with the iframe positioning relative to the other content on the video tab.)
- On mobile devices, the iframe wasn't able to expand to fullscreen. 

New format fixes those issues.